### PR TITLE
Fix: "requests must be of type application/json" problem

### DIFF
--- a/lib/post.js
+++ b/lib/post.js
@@ -4,7 +4,10 @@ export const post = async (url, body) => {
   try {
     const res = await fetch(url, {
       method: 'POST',
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json"
+      },
     });
     return await res.json();
   } catch(e) {


### PR DESCRIPTION
Hi,
I found that there are some error happens while sending the request to the piston server. 

<img width="511" height="20" alt="Screenshot 2025-12-05 at 9 35 07 pm" src="https://github.com/user-attachments/assets/30cb390c-89b5-4c39-9ef9-4b9ffeee8a10" />

I added the following code to post.js to make it work
```javascript
headers: {
  "Content-Type": "application/json"
},
```

Thank you for making this library.